### PR TITLE
coffe-files: Switch back to old JP4 partition indexes in coffee files

### DIFF
--- a/jetson-xavier-nx-devkit-emmc.coffee
+++ b/jetson-xavier-nx-devkit-emmc.coffee
@@ -38,7 +38,7 @@ module.exports =
 	configuration:
 		config:
 			partition:
-				primary: 21
+				primary: 9
 			path: '/config.json'
 
 	initialization: commonImg.initialization

--- a/jetson-xavier-nx-devkit.coffee
+++ b/jetson-xavier-nx-devkit.coffee
@@ -39,7 +39,7 @@ module.exports =
 	configuration:
 		config:
 			partition:
-				primary: 21
+				primary: 9
 			path: '/config.json'
 
 	initialization: commonImg.initialization

--- a/jetson-xavier.coffee
+++ b/jetson-xavier.coffee
@@ -37,7 +37,7 @@ module.exports =
 	configuration:
 		config:
 			partition:
-				primary: 43
+				primary: 37
 			path: '/config.json'
 
 	initialization: commonImg.initialization


### PR DESCRIPTION
Changelog-entry: coffe-files: Switch back to old JP4 partition indexes in coffee files