### PR TITLE
Remove incorrect community flag from jetson-xavier-nx-devkit-emmc

### DIFF
--- a/jetson-xavier-nx-devkit-emmc.coffee
+++ b/jetson-xavier-nx-devkit-emmc.coffee
@@ -10,7 +10,6 @@ module.exports =
 	name: 'Jetson Xavier NX Devkit eMMC'
 	arch: 'aarch64'
 	state: 'released'
-	community: true
 
 	instructions: [
 		BOARD_PREPARE


### PR DESCRIPTION
Changelog-entry: Remove incorrect community flag from jetson-xavier-nx-devkit-emmc